### PR TITLE
Flake: fix null gitRev

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
     packages = forAllSystems (pkgs: rec {
       default = pkgs.callPackage ./default.nix {
         # accurate versioning based on git rev for non tagged releases
-        gitRev = self.rev or self.dirtyRev or null;
+        gitRev = self.rev or self.dirtyRev or "unknown";
       };
 
       test = let


### PR DESCRIPTION
resolves null error when `nix run`ing the flake outside a git repository (in @emzywastaken 's instance in `/nix/store/`)