### PR TITLE
fix: nix complains unexpected argument 'withWayland'

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   kdePackages,
+  qt6,
   writeText,
   makeWrapper,
   symlinkJoin,
@@ -23,8 +24,10 @@
   };
 
   sddm-wrapped = kdePackages.sddm.override {
-    extraPackages = propagatedBuildInputs;
-    inherit withLayerShellQt withWayland;
+    extraPackages =
+      propagatedBuildInputs
+      ++ lib.optionals withWayland [ qt6.qtwayland ]
+      ++ lib.optionals withLayerShellQt [ kdePackages.layer-shell-qt ];
   };
 in
   mkDerivation (final: {

--- a/default.nix
+++ b/default.nix
@@ -15,7 +15,14 @@
   withLayerShellQt ? true,
 }: let
   inherit (lib) cleanSource licenses;
-  inherit (lib) attrValues substring readFile concatStringsSep map;
+  inherit
+    (lib)
+    attrValues
+    substring
+    readFile
+    concatStringsSep
+    map
+    ;
   inherit (lib.generators) toINI;
   inherit (stdenvNoCC) mkDerivation;
 
@@ -26,8 +33,8 @@
   sddm-wrapped = kdePackages.sddm.override {
     extraPackages =
       propagatedBuildInputs
-      ++ lib.optionals withWayland [ qt6.qtwayland ]
-      ++ lib.optionals withLayerShellQt [ kdePackages.layer-shell-qt ];
+      ++ lib.optionals withWayland [qt6.qtwayland]
+      ++ lib.optionals withLayerShellQt [kdePackages.layer-shell-qt];
   };
 in
   mkDerivation (final: {

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1754725699,
-        "narHash": "sha256-iAcj9T/Y+3DBy2J0N+yF9XQQQ8IEb5swLFzs23CdP88=",
+        "lastModified": 1758690382,
+        "narHash": "sha256-NY3kSorgqE5LMm1LqNwGne3ZLMF2/ILgLpFr1fS4X3o=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "85dbfc7aaf52ecb755f87e577ddbe6dbbdbc1054",
+        "rev": "e643668fd71b949c53f8626614b21ff71a07379d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -10,12 +10,13 @@
     nixpkgs,
   }: let
     # unsure if we need to include darwin but no harm in doing so
-    systems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
-    forAllSystems = f:
-      nixpkgs.lib.genAttrs systems (
-        system:
-          f (import nixpkgs {inherit system;})
-      );
+    systems = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f (import nixpkgs {inherit system;}));
   in {
     packages = forAllSystems (pkgs: rec {
       # you may test these themes with `nix run .#default.test`


### PR DESCRIPTION
- **flake.lock: Update**
- **flake: adapt to latest changes in sddm in nixpkgs**
- **style: format nix files with alejandra**

In recent changes to `sddm` in `nixpkgs/nixos-unstable`, the `withWayland` and `withLayerShellQt` arguments were dropped.
To address this, `default.nix` is updated by adding `qtwayland` and `layer-shell-qt` to `extraPackages` to override into `kdePackages.sddm`.

See: https://github.com/NixOS/nixpkgs/commit/ebac8437abeed8b62c195cb02a1daaf9cbfab7f6
