### PR TITLE
fix: nix theme overrides now actually apply

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -48,7 +48,8 @@ in
 
     installPhase = let
       basePath = "$out/share/sddm/themes/${final.pname}";
-      overrides = toINI {} theme-overrides;
+      overrides' = toINI {} theme-overrides;
+      overrides = builtins.replaceStrings ["="] [" = "] overrides';
     in ''
       mkdir -p ${basePath}
       cp -r $src/* ${basePath}


### PR DESCRIPTION
## TL;DR
The `toINI` function writes the config in a format that apparently sddm can't read/ignores. The fix is rather simple, though: the `=` needs space before and after. For instance:
```ini
[LoginScreen]
blur=32   ;will not override the already set value
blur = 32 ;but this will
```

---

Hi, love the theme(s), especially as a NixOS user as it comes with nix support

Still, for quite some time, the `theme-overrides` weren't applying, even if the config was in fact present in the correct `conf` file. For a couple of things a classic `overrideAttrs` would do the trick but still not the same thing

After a while, I decided to take a look more in-depth, following these steps:
- _"maybe the parser ignores already set values?"_: I tried to set the overrides on top of the already present configs but no luck
- _"maybe write only the overrides?"_: This kind of works but it would break the already present themes. It could be fixed by maybe writing them in the nix side but would be a nightmare to maintain
- _"maybe the syntax is incorrect?"_: Apparently yes, as shown in the TL;DR. I still can't explain why the "incorrect" syntax works if only the overrides are present though

This is the cleanest way of setting this I could implement (maybe pipes could make it a little bit more readable)

While I didn't test every single possible option, I did test a reasonable subset of settings so I assume it _"just works"_ for everything else