### PR TITLE
FIX - String "bottom-center" in default.conf

### DIFF
--- a/configs/default.conf
+++ b/configs/default.conf
@@ -41,7 +41,7 @@ margin-top = -15
 
 [LockScreen.Message]
 display = true
-position = "bottom"-center
+position = "bottom-center"
 align = "center"
 text = "Press any key"
 font-family = "RedHatDisplay"


### PR DESCRIPTION
I'm unsure of whether this was a mistake. My config kept crashing when I used this string, so I based my assumption on that. If it isn’t a mistake, just close the PR. Also, while I’m here: this theme is absolutely incredible, definitely one of my new favorites. Thanks!