### PR TITLE
fix: resolve tooltip text overflow and alignment issues in Qt6

### DIFF
--- a/components/Avatar.qml
+++ b/components/Avatar.qml
@@ -138,18 +138,25 @@ Rectangle {
         onMouseYChanged: updateHover()
 
         ToolTip {
+            id: toolTipControl
             parent: mouseArea
             enabled: Config.tooltipsEnable && !Config.tooltipsDisableUser
             property bool shouldShow: enabled && avatar.showTooltip || (enabled && mouseArea.isCursorInsideAvatar() && avatar.tooltipText !== "")
             visible: shouldShow
             delay: 300
+            y: -height - 10
+            x: (parent.width - width) / 2
+            
             contentItem: Text {
+                id: tooltipTextElement
                 font.family: Config.tooltipsFontFamily
                 font.pixelSize: Config.tooltipsFontSize * Config.generalScale
                 text: avatar.tooltipText
                 color: Config.tooltipsContentColor
             }
             background: Rectangle {
+                implicitWidth: tooltipTextElement.implicitWidth + (toolTipControl.leftPadding + toolTipControl.rightPadding)
+                implicitHeight: tooltipTextElement.implicitHeight + (toolTipControl.topPadding + toolTipControl.bottomPadding)
                 color: Config.tooltipsBackgroundColor
                 opacity: Config.tooltipsBackgroundOpacity
                 border.width: 0

--- a/components/IconButton.qml
+++ b/components/IconButton.qml
@@ -149,13 +149,17 @@ Item {
         cursorShape: Qt.PointingHandCursor
 
         ToolTip {
+            id: toolTipControl
             parent: mouseArea
             enabled: Config.tooltipsEnable
             property bool shouldShow: enabled && mouseArea.containsMouse && iconButton.tooltipText !== "" || enabled && iconButton.focus && iconButton.tooltipText !== ""
             visible: shouldShow
             delay: 300
+            y: -height - 10
+            x: (parent.width - width) / 2
 
             contentItem: Text {
+                id: tooltipTextElement
                 font.family: Config.tooltipsFontFamily
                 font.pixelSize: Config.tooltipsFontSize * Config.generalScale
                 text: iconButton.tooltipText
@@ -163,6 +167,8 @@ Item {
             }
 
             background: Rectangle {
+                implicitWidth: tooltipTextElement.implicitWidth + (toolTipControl.leftPadding + toolTipControl.rightPadding)
+                implicitHeight: tooltipTextElement.implicitHeight + (toolTipControl.topPadding + toolTipControl.bottomPadding)
                 color: Config.tooltipsBackgroundColor
                 opacity: Config.tooltipsBackgroundOpacity
                 border.width: 0


### PR DESCRIPTION
### Description
This PR addresses UI issues with tooltips in the Qt6 version of the SilentSDDM theme. Previously, tooltip text would overflow the background container when the text length exceeded the fixed width, and the alignment was often off-center due to property assignment restrictions in Qt6.

**Key Changes:**
- **Dynamic Sizing:** Implemented `implicitWidth` and `implicitHeight` for the tooltip background. This ensures the background scales naturally with the text content while respecting default padding.
- **Improved Centering:** Switched to a manual X-coordinate calculation `x: (parent.width - width) / 2` for the tooltip position. This provides a consistent, center-aligned look and avoids "grouped property" assignment errors common in Qt6 environments.
- **Improved UI Consistency:** Tooltips now render correctly across different screen scales and font sizes without cropping or bleeding.

---

### Visual Comparison (Before vs After)

<details>
<summary>📸 Click to view comparison table</summary>
<br />

| Before (Overflow / Misaligned) | After (Fixed / Centered) |
| :---: | :---: |
| ![before-1](https://i.ibb.co.com/gM0CZJPx/tooltips-before-1.png) | ![after-1](https://i.ibb.co.com/m5Qf4Lwd/tooltips-after-1.png) |
| ![before-2](https://i.ibb.co.com/VWD832P2/tooltips-before-2.png) | ![after-2](https://i.ibb.co.com/BH1nyHvr/tooltips-after-2.png) |
| ![before-3](https://i.ibb.co.com/TMhx7XwP/tooltips-before-3.png) | ![after-3](https://i.ibb.co.com/zTQx1GZZ/tooltips-after-3.png) |
| ![before-4](https://i.ibb.co.com/DPpDjpfh/tooltips-before-4.png) | ![after-4](https://i.ibb.co.com/RGVhbC29/tooltips-after-4.png) |

</details>

---

### System Information (Testing Environment)
- **OS:** openSUSE Leap 16
- **KDE Plasma Version:** 6.4.2
- **SDDM Greeter:** sddm-greeter-qt6
- **Theme Version:** SilentSDDM 1.4.2