### PR TITLE
Allow SDDM theme directory to be overridden.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,7 @@ grey='\033[2;37m'
 reset="\033[0m"
 
 SHPATH=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+: ${THEMES_DIR:=/usr/share/sddm/themes}
 
 install_dependencies () {
     if command -v pacman &>/dev/null; then
@@ -28,14 +29,14 @@ install_dependencies () {
 }
 
 copy_files () {
-    echo -e "${grey}Copying files from '${SHPATH}/' to '/usr/share/sddm/themes/silent/'...${reset}"
-    sudo mkdir -p /usr/share/sddm/themes/silent
-    sudo cp -rf "$SHPATH"/. /usr/share/sddm/themes/silent/
+    echo -e "${grey}Copying files from '${SHPATH}/' to '${THEMES_DIR}/silent/'...${reset}"
+    sudo mkdir -p ${THEMES_DIR}/silent
+    sudo cp -rf "$SHPATH"/. ${THEMES_DIR}/silent/
 }
 
 copy_fonts () {
     echo -e "${grey}Copying fonts to '/usr/share/fonts/'...${reset}"
-    sudo cp -r /usr/share/sddm/themes/silent/fonts/{redhat,redhat-vf} /usr/share/fonts/
+    sudo cp -r ${THEMES_DIR}/silent/fonts/{redhat,redhat-vf} /usr/share/fonts/
 }
 
 apply_theme () {
@@ -55,13 +56,13 @@ apply_theme () {
         fi
 
         # "InputMethod" was supposed to automatically set "QT_IM_MODULE", but it doesn't, so we manually export it.
-        if ! grep -Pzq 'GreeterEnvironment=QML2_IMPORT_PATH=/usr/share/sddm/themes/silent/components/,QT_IM_MODULE=qtvirtualkeyboard' /etc/sddm.conf; then
-            echo -e "\n[General]\nGreeterEnvironment=QML2_IMPORT_PATH=/usr/share/sddm/themes/silent/components/,QT_IM_MODULE=qtvirtualkeyboard" | sudo tee -a /etc/sddm.conf
+        if ! grep -Pzq 'GreeterEnvironment=QML2_IMPORT_PATH=${THEMES_DIR}/silent/components/,QT_IM_MODULE=qtvirtualkeyboard' /etc/sddm.conf; then
+            echo -e "\n[General]\nGreeterEnvironment=QML2_IMPORT_PATH=${THEMES_DIR}/silent/components/,QT_IM_MODULE=qtvirtualkeyboard" | sudo tee -a /etc/sddm.conf
         fi
     else
         echo -e "[Theme]\nCurrent=silent" | sudo tee -a /etc/sddm.conf
         echo -e "\n[General]\nInputMethod=qtvirtualkeyboard" | sudo tee -a /etc/sddm.conf
-        echo -e "GreeterEnvironment=QML2_IMPORT_PATH=/usr/share/sddm/themes/silent/components/,QT_IM_MODULE=qtvirtualkeyboard" | sudo tee -a /etc/sddm.conf
+        echo -e "GreeterEnvironment=QML2_IMPORT_PATH=${THEMES_DIR}/silent/components/,QT_IM_MODULE=qtvirtualkeyboard" | sudo tee -a /etc/sddm.conf
     fi
 }
 

--- a/test.sh
+++ b/test.sh
@@ -6,6 +6,8 @@ cyan='\033[0;36m'
 grey='\033[2;37m'
 reset="\033[0m"
 
+: ${THEMES_DIR:=/usr/share/sddm/themes}
+
 # Test for debug param ( debug | -debug | -d | --debug )
 if [[ "$1" =~ ^(debug|-debug|--debug|-d)$ ]]; then
     QT_IM_MODULE=qtvirtualkeyboard QML2_IMPORT_PATH=./components/ sddm-greeter-qt6 --test-mode --theme .
@@ -15,9 +17,9 @@ else
     QT_IM_MODULE=qtvirtualkeyboard QML2_IMPORT_PATH=./components/ sddm-greeter-qt6 --test-mode --theme . > /dev/null 2>&1
 fi
 
-if [ ! -d "/usr/share/sddm/themes/silent" ]; then
+if [ ! -d "${THEMES_DIR}/silent" ]; then
     echo -e "\n${bred}[WARNING]: ${red}theme not installed!${reset}"
-    echo -e "Run ${cyan}'./install.sh'${reset} or copy the contents of the theme to ${cyan}'/usr/share/sddm/themes/silent/'${reset} and set the current theme to ${cyan}'silent'${reset} in ${cyan}'/etc/sddm.conf'${reset}:\n"
+    echo -e "Run ${cyan}'./install.sh'${reset} or copy the contents of the theme to ${cyan}'${THEMES_DIR}/silent/'${reset} and set the current theme to ${cyan}'silent'${reset} in ${cyan}'/etc/sddm.conf'${reset}:\n"
     echo -e "    ${grey}# /etc/sddm.conf${reset}"
     echo -e "    [Theme]"
     echo -e "    Current=silent"


### PR DESCRIPTION
On FreeBSD (and probably other BSDs), non-base package files go into /usr/local/foo rather than /usr/foo. Provide an option for users to specify a THEMES_DIR environment variable like /usr/local/sddm/themes when they run install.sh and test.sh, enabling those scripts to work correctly on FreeBSD.