### PR TITLE
feat: Install font with nixos options

### DIFF
--- a/nix/fonts.nix
+++ b/nix/fonts.nix
@@ -1,0 +1,17 @@
+{stdenv, ...}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fonts";
+  version = "dummy";
+
+  src = ../fonts;
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/fonts/opentype
+    mkdir -p $out/share/fonts/truetype
+    install -Dm644 $src/redhat/*.otf -t $out/share/fonts/opentype
+    install -Dm644 $src/redhat-vf/*.ttf -t $out/share/fonts/truetype
+    runHook postInstall
+  '';
+})

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -2,6 +2,7 @@
   lib,
   pkgs,
   config,
+  callPackage,
   ...
 }: let
   inherit (lib) map pipe flatten flip elem assertMsg;
@@ -151,6 +152,10 @@ in {
         };
       };
     };
+    fonts.packages = [
+      (pkgs.callPackage
+        ./fonts.nix {})
+    ];
 
     # setup profile pictures
     systemd.tmpfiles.rules = mkIf (cfg.profileIcons != {}) cfg.profileIcons';


### PR DESCRIPTION
This adds font installation step for nixosModules. Since there is no definition for home-manager module, I skipped it.

Tested on my personal configuration and font is installed and displayed correctly(which is not before):

```nix
inputs = {
    silentSDDM = {
      url = "github:kagurazaka-ayano/SilentSDDM/feat/font";
      inputs.nixpkgs.follows = "nixpkgs";
    };
}
...
  imports = [inputs.silentSDDM.nixosModules.default];
  programs.silentSDDM = {
    enable = true;
    theme = "catppuccin-mocha";
    profileIcons = {
      ...
    };
    settings = {
    };
  };
```