### PR TITLE
Correct code block formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,13 +109,13 @@ sudoedit /etc/sddm.conf
 ```bash
 
 
-    # Make sure these options are correct:
-    [General]
-    InputMethod=qtvirtualkeyboard
-    GreeterEnvironment=QML2_IMPORT_PATH=/usr/share/sddm/themes/silent/components/,QT_IM_MODULE=qtvirtualkeyboard
+# Make sure these options are correct:
+[General]
+InputMethod=qtvirtualkeyboard
+GreeterEnvironment=QML2_IMPORT_PATH=/usr/share/sddm/themes/silent/components/,QT_IM_MODULE=qtvirtualkeyboard
 
-    [Theme]
-    Current=silent
+[Theme]
+Current=silent
 ```
 Finally, test the theme to make sure everything is working:
 ```bash

--- a/README.md
+++ b/README.md
@@ -102,8 +102,12 @@ yay -S sddm-silent-theme
 yay -S sddm-silent-theme-git
 ```
 Then, replace the current theme and set the environment variables in `/etc/sddm.conf`:
-```bash
+```
 sudoedit /etc/sddm.conf
+```
+
+```bash
+
 
     # Make sure these options are correct:
     [General]


### PR DESCRIPTION
Fix formatting issues in README.md for SDDM theme setup instructions.
Because earlier it seemed little bit confusing for having the sudoedit command as well in the code block.